### PR TITLE
chore: EthBytes, EthInt, EthUint, Hex improvements:

### DIFF
--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthBytes.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthBytes.java
@@ -102,8 +102,7 @@ public class EthBytes implements EthValue, EthNumericValue<EthBytes>, EthSizedVa
      */
     @Override
     public @NotNull EthBytes withValue(@NotNull BigInteger value) {
-        val arrayValue = Hex.toByteArray(Hex.toHex(value));
-        return new EthBytes(size, arrayValue);
+        return new EthBytes(size, value.toByteArray());
     }
 
     /**
@@ -359,7 +358,6 @@ public class EthBytes implements EthValue, EthNumericValue<EthBytes>, EthSizedVa
 
     @NotNull
     public static EthBytes bytes(@NotNull String hex) {
-        require(Hex.isValid(hex), "Malformed hex string: {}", hex);
         return bytes(Hex.toByteArray(hex));
     }
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
@@ -185,7 +185,6 @@ public class EthInt extends Number implements EthValue, EthNumericValue<EthInt>,
 
     @NotNull
     public static EthInt int256(@NotNull String hex) {
-        require(Hex.isValid(hex), "Malformed hex string: {}", hex);
         return int256(Hex.toBigInteger(hex));
     }
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
@@ -185,7 +185,6 @@ public class EthUint extends Number implements EthValue, EthNumericValue<EthUint
 
     @NotNull
     public static EthUint uint256(@NotNull String hex) {
-        require(Hex.isValid(hex), "Malformed hex string: {}", hex);
         return uint256(Hex.toBigInteger(hex));
     }
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/Hex.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/Hex.java
@@ -1,7 +1,6 @@
 package dev.klepto.kweb3.core.util;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.io.BaseEncoding;
+import com.esaulpaugh.headlong.util.FastHex;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,32 +12,30 @@ import java.math.BigInteger;
  * @author <a href="http://github.com/klepto">Augustinas R.</a>
  */
 public final class Hex {
-
-    private static final String VALID_HEX = "0123456789abcdefABCDEF";
+    private static final String ZERO_WITH_PREFIX = "0x0";
+    private static final String ZERO = "0";
 
     private Hex() {
     }
 
     /**
-     * Checks if a given string value is a valid hexadecimal string.
+     * Decodes the specified hexadecimal string to a byte array.
      *
-     * @param value the string value to check
-     * @return true if given string value is a hexadecimal string
+     * @param hex the hexadecimal string, may contain <code>0x</code> prefix
+     * @return a byte array containing decoded hexadecimal string
      */
-    public static boolean isValid(@NotNull String value) {
-        value = stripPrefix(value);
-        return value.chars().allMatch(character -> VALID_HEX.indexOf(character) >= 0);
-    }
-
-    /**
-     * Strips the default <code>0x</code> prefix from hexadecimal string.
-     *
-     * @param hex a hexadecimal string that may or may not contain <code>0x</code> prefix
-     * @return a hexadecimal string without the default prefix
-     */
-    @NotNull
-    public static String stripPrefix(@NotNull String hex) {
-        return hex.toLowerCase().replace("0x", "");
+    public static byte @NotNull [] toByteArray(@NotNull String hex) {
+        var offset = 0;
+        var length = hex.length();
+        if (length >= 2) {
+            val first = hex.charAt(0);
+            val second = hex.charAt(1);
+            if (first == '0' && (second == 'x' || second == 'X')) {
+                offset = 2;
+                length -= 2;
+            }
+        }
+        return FastHex.decode(hex, offset, length);
     }
 
     /**
@@ -49,7 +46,7 @@ public final class Hex {
      */
     @NotNull
     public static String toHex(byte @NotNull [] value) {
-        return toHex(value, true, true);
+        return toHex(value, true);
     }
 
     /**
@@ -57,58 +54,29 @@ public final class Hex {
      *
      * @param value       the byte array value
      * @param prefix      if true, appends <code>0x</code> prefix to the resulting string
-     * @param leadingZero if true, ensures that result length is divisible by 2
+     * @apiNote this method uses a deprecated {@link String} constructor to avoid unnecessary memory allocation
+     *  and to improve performance. This method is safe to use as long as the input is a valid hexadecimal string.
      * @return a hexadecimal representation of integer
      */
     @NotNull
-    public static String toHex(byte @NotNull [] value, boolean prefix, boolean leadingZero) {
+    @SuppressWarnings("deprecation")
+    public static String toHex(byte @NotNull [] value, boolean prefix) {
         if (value.length == 0) {
-            return prefix ? "0x0" : "0";
+            return prefix ? ZERO_WITH_PREFIX : ZERO;
         }
 
-        var hex = BaseEncoding.base16().encode(value).toLowerCase();
-        if (!leadingZero) {
-            hex = CharMatcher.is('0').trimLeadingFrom(hex);
-            if (hex.isEmpty()) {
-                hex = "0";
-            }
-        }
+        // TODO: This could be faster if we moved to a custom implementation
+        //  which doesn't force us to deal with this intermediate array resizing
+        //  and copying. It's ok for now, but could be improved.
+        val hex = FastHex.encodeToBytes(value);
         if (prefix) {
-            hex = "0x" + hex;
+            val prefixed = new byte[hex.length + 2];
+            prefixed[0] = '0';
+            prefixed[1] = 'x';
+            System.arraycopy(hex, 0, prefixed, 2, hex.length);
+            return new String(prefixed, 0, 0, prefixed.length);
         }
-        return hex;
-    }
-
-    /**
-     * Converts {@link BigInteger} to a hexadecimal string with <code>0x</code> prefix and leading zeros.
-     *
-     * @param value the integer value
-     * @return a hexadecimal representation of integer
-     */
-    @NotNull
-    public static String toHex(@NotNull BigInteger value) {
-        return toHex(value, true, true);
-    }
-
-    /**
-     * Converts {@link BigInteger} to a hexadecimal string.
-     *
-     * @param value       the integer value
-     * @param prefix      if true, appends <code>0x</code> prefix to the resulting string
-     * @param leadingZero if true, ensures that result length is divisible by 2
-     * @return a hexadecimal representation of integer
-     */
-    @NotNull
-    public static String toHex(@NotNull BigInteger value, boolean prefix, boolean leadingZero) {
-        if (value.equals(BigInteger.ZERO)) {
-            return prefix ? "0x0" : "0";
-        }
-        
-        var hex = value.toString(16).toLowerCase();
-        if (leadingZero && hex.length() % 2 != 0) {
-            hex = "0" + hex;
-        }
-        return (prefix ? "0x" : "") + hex;
+        return new String(hex, 0, 0, hex.length);
     }
 
     /**
@@ -119,28 +87,7 @@ public final class Hex {
      */
     @NotNull
     public static BigInteger toBigInteger(@NotNull String hex) {
-        val stripped = stripPrefix(hex);
-        if (stripped.isEmpty()) {
-            return BigInteger.ZERO;
-        }
-
-        return new BigInteger(stripPrefix(hex), 16);
-    }
-
-    /**
-     * Converts given hexadecimal string to <code>byte</code> array.
-     *
-     * @param hex the hexadecimal string
-     * @return a byte array containing hexadecimal string value
-     */
-    public static byte @NotNull [] toByteArray(@NotNull String hex) {
-        val stripped = stripPrefix(hex);
-        if (stripped.isEmpty()) {
-            return new byte[0];
-        }
-
-        val encoding = BaseEncoding.base16().omitPadding();
-        return encoding.decode(stripped.toUpperCase());
+        return new BigInteger(toByteArray(hex));
     }
 
 }


### PR DESCRIPTION
- Get rid of `Hex#isValid`, `FastHex` from headlong performs optimized validation on our behalf
- Get rid of `leadingZero` encoding option as according to Solidity spec: <https://docs.soliditylang.org/en/latest/types.html#index-34> this option is invalid. Hex strings must conform to the exact byte size (meaning the array must always be padded to a length divisible by 2)
- Get rid of string concatenation entirely, very slow operation, lots of unnecessary copying.