### PR TITLE
Chore/eth address improvements

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.3" }
 unirest-core = { module = "com.konghq:unirest-java-core", version.ref = "unirest" }
 unirest-gson = { module = "com.konghq:unirest-modules-gson", version.ref = "unirest" }
+ethers-bom = { module = "io.kriptal.ethers:ethers-bom", version = "0.5.0" }
+ethers-core = { module = "io.kriptal.ethers:ethers-core" }
 
 [bundles]
 slf4j = ["slf4j-api", "slf4j-simple"]

--- a/kweb3-core/build.gradle.kts
+++ b/kweb3-core/build.gradle.kts
@@ -11,6 +11,9 @@ dependencies {
     implementation(libs.unirest.core)
     implementation(libs.unirest.gson)
 
+    implementation(platform(libs.ethers.bom))
+    implementation(libs.ethers.core)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/abi/HeadlongCodec.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/abi/HeadlongCodec.java
@@ -3,7 +3,6 @@ package dev.klepto.kweb3.core.ethereum.abi;
 import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TupleType;
-import com.esaulpaugh.headlong.util.FastHex;
 import dev.klepto.kweb3.core.ethereum.abi.descriptor.EthArrayTypeDescriptor;
 import dev.klepto.kweb3.core.ethereum.abi.descriptor.EthSizedTypeDescriptor;
 import dev.klepto.kweb3.core.ethereum.abi.descriptor.EthTupleTypeDescriptor;
@@ -12,6 +11,7 @@ import dev.klepto.kweb3.core.ethereum.type.EthNumericValue;
 import dev.klepto.kweb3.core.ethereum.type.EthSizedValue;
 import dev.klepto.kweb3.core.ethereum.type.EthValue;
 import dev.klepto.kweb3.core.ethereum.type.primitive.*;
+import io.ethers.core.FastHex;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -210,7 +210,7 @@ public class HeadlongCodec implements AbiCodec {
     private String encode(EthTuple value, TypeDescriptor descriptor) {
         val tupleType = TupleType.parse(descriptor.toAbiDescriptor());
         val result = tupleType.encode((Tuple) encodeValue(value)).array();
-        return FastHex.encodeToString(result, 0, result.length);
+        return FastHex.encodeWithoutPrefix(result);
     }
 
     /**

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthAddress.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthAddress.java
@@ -1,21 +1,14 @@
 package dev.klepto.kweb3.core.ethereum.type.primitive;
 
-import com.google.common.base.Strings;
+import com.esaulpaugh.headlong.abi.Address;
 import dev.klepto.kweb3.core.ethereum.type.EthNumericValue;
 import dev.klepto.kweb3.core.ethereum.type.EthValue;
-import dev.klepto.kweb3.core.util.Hex;
-import dev.klepto.kweb3.core.util.hash.Keccak256;
 import lombok.With;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
-
-import static dev.klepto.kweb3.core.util.Conditions.require;
-import static dev.klepto.kweb3.core.util.Hex.stripPrefix;
-import static dev.klepto.kweb3.core.util.Hex.toBigInteger;
-import static dev.klepto.kweb3.core.util.hash.Keccak256.keccak256Checksum;
 
 /**
  * Container for <code>ethereum address</code> value.
@@ -34,16 +27,33 @@ public class EthAddress implements EthValue, EthNumericValue<EthAddress> {
      * Address value.
      */
     @NotNull
-    private final BigInteger value;
+    private final Address address;
 
     /**
-     * Constructs new <code>ethereum address</code> from the specified big integer value.
-     *
-     * @param value the big integer value
+     * Checksum address value.
      */
-    public EthAddress(@NotNull BigInteger value) {
-        require(value.bitLength() <= 160, "Malformed address: {}", Hex.toHex(value));
-        this.value = value;
+    @NotNull
+    private final String checksumAddress;
+
+    /**
+     * Constructs new <code>ethereum address</code> from the specified {@link Address}.
+     *
+     * @param address the address
+     */
+    private EthAddress(@NotNull Address address, @NotNull String checksumAddress) {
+        this.address = address;
+        this.checksumAddress = checksumAddress;
+    }
+
+    /**
+     * Creates a new instance of numeric type with given value.
+     *
+     * @param value the value to set
+     * @return a new instance of numeric type with given value
+     */
+    @Override
+    public @NotNull EthAddress withValue(@NotNull BigInteger value) {
+        return address(value);
     }
 
     /**
@@ -53,19 +63,17 @@ public class EthAddress implements EthValue, EthNumericValue<EthAddress> {
      */
     @Override
     public @NotNull BigInteger value() {
-        return value;
+        return address.value();
     }
 
     /**
-     * Generates a hex of this <code>ethereum address</code> with checksum.
+     * Returns the checksum hex of this <code>ethereum address</code> with checksum.
      *
      * @return a check-summed hex of this <code>ethereum address</code>
      */
     @Override
     public @NotNull String toHex() {
-        val hex = value().toString(16);
-        val paddedHex = Strings.padStart(hex, 40, '0');
-        return keccak256Checksum(paddedHex);
+        return checksumAddress;
     }
 
     /**
@@ -86,7 +94,7 @@ public class EthAddress implements EthValue, EthNumericValue<EthAddress> {
      */
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return address.hashCode();
     }
 
     /**
@@ -121,19 +129,20 @@ public class EthAddress implements EthValue, EthNumericValue<EthAddress> {
         if (!(object instanceof EthAddress other)) {
             return false;
         }
-        return value.equals(other.value);
+        return checksumAddress.equals(other.checksumAddress);
     }
 
     /* Solidity style static initializers */
     @NotNull
     public static EthAddress address(@NotNull Number value) {
-        return new EthAddress(EthNumericValue.parseBigInteger(value));
+        val checksumAddress = Address.toChecksumAddress(EthNumericValue.parseBigInteger(value));
+        return address(checksumAddress);
     }
 
     @NotNull
     public static EthAddress address(@NotNull String hex) {
-        hex = stripPrefix(Keccak256.keccak256Checksum(hex));
-        return address(toBigInteger(hex));
+        val address = Address.wrap(hex);
+        return new EthAddress(address, address.toString());
     }
 
 }

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthBytes.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthBytes.java
@@ -102,8 +102,7 @@ public class EthBytes implements EthValue, EthNumericValue<EthBytes>, EthSizedVa
      */
     @Override
     public @NotNull EthBytes withValue(@NotNull BigInteger value) {
-        val arrayValue = Hex.toByteArray(Hex.toHex(value));
-        return new EthBytes(size, arrayValue);
+        return new EthBytes(size, value.toByteArray());
     }
 
     /**
@@ -359,7 +358,6 @@ public class EthBytes implements EthValue, EthNumericValue<EthBytes>, EthSizedVa
 
     @NotNull
     public static EthBytes bytes(@NotNull String hex) {
-        require(Hex.isValid(hex), "Malformed hex string: {}", hex);
         return bytes(Hex.toByteArray(hex));
     }
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
@@ -185,7 +185,6 @@ public class EthInt extends Number implements EthValue, EthNumericValue<EthInt>,
 
     @NotNull
     public static EthInt int256(@NotNull String hex) {
-        require(Hex.isValid(hex), "Malformed hex string: {}", hex);
         return int256(Hex.toBigInteger(hex));
     }
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
@@ -185,7 +185,7 @@ public class EthInt extends Number implements EthValue, EthNumericValue<EthInt>,
 
     @NotNull
     public static EthInt int256(@NotNull String hex) {
-        return int256(Hex.toBigInteger(hex));
+        return new EthInt(256, Hex.toBigInteger(hex));
     }
 
     /* Smaller size solidity int initializers */

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
@@ -185,7 +185,6 @@ public class EthUint extends Number implements EthValue, EthNumericValue<EthUint
 
     @NotNull
     public static EthUint uint256(@NotNull String hex) {
-        require(Hex.isValid(hex), "Malformed hex string: {}", hex);
         return uint256(Hex.toBigInteger(hex));
     }
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/Hex.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/Hex.java
@@ -1,7 +1,6 @@
 package dev.klepto.kweb3.core.util;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.io.BaseEncoding;
+import com.esaulpaugh.headlong.util.FastHex;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,32 +12,30 @@ import java.math.BigInteger;
  * @author <a href="http://github.com/klepto">Augustinas R.</a>
  */
 public final class Hex {
-
-    private static final String VALID_HEX = "0123456789abcdefABCDEF";
+    private static final String ZERO_WITH_PREFIX = "0x0";
+    private static final String ZERO = "0";
 
     private Hex() {
     }
 
     /**
-     * Checks if a given string value is a valid hexadecimal string.
+     * Decodes the specified hexadecimal string to a byte array.
      *
-     * @param value the string value to check
-     * @return true if given string value is a hexadecimal string
+     * @param hex the hexadecimal string, may contain <code>0x</code> prefix
+     * @return a byte array containing decoded hexadecimal string
      */
-    public static boolean isValid(@NotNull String value) {
-        value = stripPrefix(value);
-        return value.chars().allMatch(character -> VALID_HEX.indexOf(character) >= 0);
-    }
-
-    /**
-     * Strips the default <code>0x</code> prefix from hexadecimal string.
-     *
-     * @param hex a hexadecimal string that may or may not contain <code>0x</code> prefix
-     * @return a hexadecimal string without the default prefix
-     */
-    @NotNull
-    public static String stripPrefix(@NotNull String hex) {
-        return hex.toLowerCase().replace("0x", "");
+    public static byte @NotNull [] toByteArray(@NotNull String hex) {
+        var offset = 0;
+        var length = hex.length();
+        if (length >= 2) {
+            val first = hex.charAt(0);
+            val second = hex.charAt(1);
+            if (first == '0' && (second == 'x' || second == 'X')) {
+                offset = 2;
+                length -= 2;
+            }
+        }
+        return FastHex.decode(hex, offset, length);
     }
 
     /**
@@ -49,7 +46,7 @@ public final class Hex {
      */
     @NotNull
     public static String toHex(byte @NotNull [] value) {
-        return toHex(value, true, true);
+        return toHex(value, true);
     }
 
     /**
@@ -57,58 +54,29 @@ public final class Hex {
      *
      * @param value       the byte array value
      * @param prefix      if true, appends <code>0x</code> prefix to the resulting string
-     * @param leadingZero if true, ensures that result length is divisible by 2
+     * @apiNote this method uses a deprecated {@link String} constructor to avoid unnecessary memory allocation
+     *  and to improve performance. This method is safe to use as long as the input is a valid hexadecimal string.
      * @return a hexadecimal representation of integer
      */
     @NotNull
-    public static String toHex(byte @NotNull [] value, boolean prefix, boolean leadingZero) {
+    @SuppressWarnings("deprecation")
+    public static String toHex(byte @NotNull [] value, boolean prefix) {
         if (value.length == 0) {
-            return prefix ? "0x0" : "0";
+            return prefix ? ZERO_WITH_PREFIX : ZERO;
         }
 
-        var hex = BaseEncoding.base16().encode(value).toLowerCase();
-        if (!leadingZero) {
-            hex = CharMatcher.is('0').trimLeadingFrom(hex);
-            if (hex.isEmpty()) {
-                hex = "0";
-            }
-        }
+        // TODO: This could be faster if we moved to a custom implementation
+        //  which doesn't force us to deal with this intermediate array resizing
+        //  and copying. It's ok for now, but could be improved.
+        val hex = FastHex.encodeToBytes(value);
         if (prefix) {
-            hex = "0x" + hex;
+            val prefixed = new byte[hex.length + 2];
+            prefixed[0] = '0';
+            prefixed[1] = 'x';
+            System.arraycopy(hex, 0, prefixed, 2, hex.length);
+            return new String(prefixed, 0, 0, prefixed.length);
         }
-        return hex;
-    }
-
-    /**
-     * Converts {@link BigInteger} to a hexadecimal string with <code>0x</code> prefix and leading zeros.
-     *
-     * @param value the integer value
-     * @return a hexadecimal representation of integer
-     */
-    @NotNull
-    public static String toHex(@NotNull BigInteger value) {
-        return toHex(value, true, true);
-    }
-
-    /**
-     * Converts {@link BigInteger} to a hexadecimal string.
-     *
-     * @param value       the integer value
-     * @param prefix      if true, appends <code>0x</code> prefix to the resulting string
-     * @param leadingZero if true, ensures that result length is divisible by 2
-     * @return a hexadecimal representation of integer
-     */
-    @NotNull
-    public static String toHex(@NotNull BigInteger value, boolean prefix, boolean leadingZero) {
-        if (value.equals(BigInteger.ZERO)) {
-            return prefix ? "0x0" : "0";
-        }
-        
-        var hex = value.toString(16).toLowerCase();
-        if (leadingZero && hex.length() % 2 != 0) {
-            hex = "0" + hex;
-        }
-        return (prefix ? "0x" : "") + hex;
+        return new String(hex, 0, 0, hex.length);
     }
 
     /**
@@ -119,28 +87,7 @@ public final class Hex {
      */
     @NotNull
     public static BigInteger toBigInteger(@NotNull String hex) {
-        val stripped = stripPrefix(hex);
-        if (stripped.isEmpty()) {
-            return BigInteger.ZERO;
-        }
-
-        return new BigInteger(stripPrefix(hex), 16);
-    }
-
-    /**
-     * Converts given hexadecimal string to <code>byte</code> array.
-     *
-     * @param hex the hexadecimal string
-     * @return a byte array containing hexadecimal string value
-     */
-    public static byte @NotNull [] toByteArray(@NotNull String hex) {
-        val stripped = stripPrefix(hex);
-        if (stripped.isEmpty()) {
-            return new byte[0];
-        }
-
-        val encoding = BaseEncoding.base16().omitPadding();
-        return encoding.decode(stripped.toUpperCase());
+        return new BigInteger(toByteArray(hex));
     }
 
 }

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/Hex.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/Hex.java
@@ -32,7 +32,6 @@ public final class Hex {
             val second = hex.charAt(1);
             if (first == '0' && (second == 'x' || second == 'X')) {
                 offset = 2;
-                length -= 2;
             }
         }
         return FastHex.decode(hex, offset, length);

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/hash/Keccak256.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/util/hash/Keccak256.java
@@ -1,6 +1,5 @@
 package dev.klepto.kweb3.core.util.hash;
 
-import com.google.common.base.Strings;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,30 +15,6 @@ import java.nio.charset.StandardCharsets;
 public final class Keccak256 {
 
     private Keccak256() {
-    }
-
-    /**
-     * Generates checksum hexadecimal string for a given hexadecimal string. The resulting hash is always prefixed with
-     * <code>0x</code>
-     *
-     * @param hex the hexadecimal string
-     * @return the checksum hash
-     */
-    @NotNull
-    public static String keccak256Checksum(@NotNull String hex) {
-        hex = hex.toLowerCase().replace("0x", "");
-        hex = Strings.padStart(hex, 40, '0');
-        val checksumHash = keccak256(hex);
-
-        val result = new StringBuilder();
-        for (var i = 0; i < hex.length(); i++) {
-            val character = hex.charAt(i) + "";
-            val checksum = checksumHash.charAt(i) + "";
-            val uppercase = Integer.parseInt(checksum, 16) >= 8;
-            result.append(uppercase ? character.toUpperCase() : character);
-        }
-
-        return "0x" + result;
     }
 
     /**
@@ -63,16 +38,6 @@ public final class Keccak256 {
     @NotNull
     public static String keccak256(String input, @NotNull Charset charset) {
         return String.format("%064x", new BigInteger(1, keccak256Bytes(input, charset)));
-    }
-
-    /**
-     * Applies Keccak-256 algorithm on given input string with default charset and returns byte array result.
-     *
-     * @param input the input string
-     * @return the resulting byte array
-     */
-    public static byte @NotNull [] keccak256Bytes(@NotNull String input) {
-        return keccak256Bytes(input, StandardCharsets.US_ASCII);
     }
 
     /**

--- a/kweb3-core/src/test/java/dev/klepto/kweb3/abi/HeadlongCodecTest.java
+++ b/kweb3-core/src/test/java/dev/klepto/kweb3/abi/HeadlongCodecTest.java
@@ -126,6 +126,14 @@ public class HeadlongCodecTest {
                         new EthSizedTypeDescriptor(EthUint.class, 256)
                 ).get(0)
         );
+
+        assertEquals(
+                int256("F8A432EB"),
+                codec.decode(
+                        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffff8a432eb",
+                        new EthSizedTypeDescriptor(EthInt.class, 256)
+                ).get(0)
+        );
     }
 
     @Test


### PR DESCRIPTION
Reasoning:
- Our logs indicate that `toHex` and address creation are blocking for significant amounts of time with large database queries (check team chat for stacks)
- EthAddress now enforces eip-55 mixed-case checksum address encoding (meaning all addresses must be checksummed to ensure they are valid ethereum addresses)
- `toHex` now always returns the checksummed address, and it's cached on creation
- Removed internal hex checksum utils, use implementation from headlong (does not use toLowerCase() or replace() which are significant slow-downs)
- EthAddress can no longer be directly instantiated, use the solidity-style static initializers
- Get rid of `Hex#isValid`, `FastHex` from headlong performs optimized validation on our behalf
- Get rid of `leadingZero` encoding option as according to Solidity spec: <https://docs.soliditylang.org/en/latest/types.html#index-34> this option is invalid. Hex strings must conform to the exact byte size (meaning the array must always be padded to a length divisible by 2)
- Get rid of string concatenation entirely, very slow operation, lots of unnecessary copying.
- Add test for negative hex